### PR TITLE
Add new modules for elasticache redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.tfvars
+*.tfstate*
+.terraform/

--- a/elasticache-redis/modules/elasticache-redis-enc/main.tf
+++ b/elasticache-redis/modules/elasticache-redis-enc/main.tf
@@ -1,0 +1,37 @@
+locals {
+  name            = "${var.project}-${var.app}-${var.stage}"
+  name_underscore = "${var.project}_${var.app}_${var.stage}"
+
+  tags = "${
+    merge(
+      map(
+        "Name", "${local.name}",
+        "Project", "${var.project}",
+        "Stage", "${var.stage}",
+        "App", "${var.app}"
+      ), var.tags
+    )
+  }"
+}
+
+resource "aws_elasticache_subnet_group" "default" {
+  name       = "${lower(local.name)}"
+  subnet_ids = ["${var.subnets}"]
+}
+
+resource "aws_elasticache_replication_group" "redis_enc" {
+  replication_group_id          = "${lower(substr(local.name, 0, 20))}"
+  replication_group_description = "Replication group for Redis"
+  automatic_failover_enabled    = "${var.automatic_failover_enabled}"
+  number_cache_clusters         = "${var.desired_clusters}"
+  node_type                     = "${var.instance_type}"
+  parameter_group_name          = "${var.parameter_group}"
+  subnet_group_name             = "${aws_elasticache_subnet_group.default.name}"
+  security_group_ids            = ["${var.security_group_ids}"]
+  port                          = "${var.port}"
+  maintenance_window            = "${var.maintenance_window}"
+  at_rest_encryption_enabled    = "true"
+  transit_encryption_enabled    = "true"
+  auth_token                    = "${var.auth_token}"
+  tags                          = "${local.tags}"
+}

--- a/elasticache-redis/modules/elasticache-redis-enc/output.tf
+++ b/elasticache-redis/modules/elasticache-redis-enc/output.tf
@@ -1,0 +1,14 @@
+output "id" {
+  value       = "${join("", aws_elasticache_replication_group.redis.*.id)}"
+  description = "Redis cluster ID"
+}
+
+output "port" {
+  value       = "${var.port}"
+  description = "Redis port"
+}
+
+output "endpoint" {
+  value       = "${join("", aws_elasticache_replication_group.redis.*.primary_endpoint_address)}"
+  description = "Endpoint URL address"
+}

--- a/elasticache-redis/modules/elasticache-redis-enc/variables.tf
+++ b/elasticache-redis/modules/elasticache-redis-enc/variables.tf
@@ -1,0 +1,44 @@
+variable "project" {}
+
+variable "stage" {}
+
+variable "app" {}
+
+variable "tags" {
+  type    = "map"
+  default = {}
+}
+
+variable "subnets" {
+  type = "list"
+}
+
+variable "automatic_failover_enabled" {
+  default = false
+}
+
+variable "desired_clusters" {
+  default = "1"
+}
+
+variable "instance_type" {
+  default = "cache.t2.micro"
+}
+
+variable "parameter_group" {
+  default = "default.redis5.0"
+}
+
+variable "security_group_ids" {
+  type = "list"
+}
+
+variable "port" {
+  default = "6379"
+}
+
+variable "maintenance_window" {
+  default = "wed:03:00-wed:04:00"
+}
+
+variable "auth_token" {}

--- a/elasticache-redis/modules/elasticache-redis/main.tf
+++ b/elasticache-redis/modules/elasticache-redis/main.tf
@@ -1,0 +1,36 @@
+locals {
+  name            = "${var.project}-${var.app}-${var.stage}"
+  name_underscore = "${var.project}_${var.app}_${var.stage}"
+
+  tags = "${
+    merge(
+      map(
+        "Name", "${local.name}",
+        "Project", "${var.project}",
+        "Stage", "${var.stage}",
+        "App", "${var.app}"
+      ), var.tags
+    )
+  }"
+}
+
+resource "aws_elasticache_subnet_group" "default" {
+  name       = "${lower(local.name)}"
+  subnet_ids = ["${var.subnets}"]
+}
+
+resource "aws_elasticache_replication_group" "redis" {
+  replication_group_id          = "${lower(substr(local.name, 0, 20))}"
+  replication_group_description = "Replication group for Redis"
+  automatic_failover_enabled    = "${var.automatic_failover_enabled}"
+  number_cache_clusters         = "${var.desired_clusters}"
+  node_type                     = "${var.instance_type}"
+  parameter_group_name          = "${var.parameter_group}"
+  subnet_group_name             = "${aws_elasticache_subnet_group.default.name}"
+  security_group_ids            = ["${var.security_group_ids}"]
+  port                          = "${var.port}"
+  maintenance_window            = "${var.maintenance_window}"
+  at_rest_encryption_enabled    = "false"
+  transit_encryption_enabled    = "false"
+  tags                          = "${local.tags}"
+}

--- a/elasticache-redis/modules/elasticache-redis/output.tf
+++ b/elasticache-redis/modules/elasticache-redis/output.tf
@@ -1,0 +1,14 @@
+output "id" {
+  value       = "${join("", aws_elasticache_replication_group.redis.*.id)}"
+  description = "Redis cluster ID"
+}
+
+output "port" {
+  value       = "${var.port}"
+  description = "Redis port"
+}
+
+output "endpoint" {
+  value       = "${join("", aws_elasticache_replication_group.redis.*.primary_endpoint_address)}"
+  description = "Endpoint URL address"
+}

--- a/elasticache-redis/modules/elasticache-redis/variables.tf
+++ b/elasticache-redis/modules/elasticache-redis/variables.tf
@@ -1,0 +1,42 @@
+variable "project" {}
+
+variable "stage" {}
+
+variable "app" {}
+
+variable "tags" {
+  type    = "map"
+  default = {}
+}
+
+variable "subnets" {
+  type = "list"
+}
+
+variable "automatic_failover_enabled" {
+  default = false
+}
+
+variable "desired_clusters" {
+  default = "1"
+}
+
+variable "instance_type" {
+  default = "cache.t2.micro"
+}
+
+variable "parameter_group" {
+  default = "default.redis5.0"
+}
+
+variable "security_group_ids" {
+  type = "list"
+}
+
+variable "port" {
+  default = "6379"
+}
+
+variable "maintenance_window" {
+  default = "wed:03:00-wed:04:00"
+}


### PR DESCRIPTION
Adding two modules for redis:
- elasticache-redis: encryption is disabled
- elasticache-redis-enc: encryption is enabled, and the auth_token is
mandatory

The reason for adding two modules instead of one is that we can't have 
auth_token unset when encryption is disabled, which creates conflict on our
workflow